### PR TITLE
Add concurrency to GH Actions workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,6 @@ on:
       - main
       - 'releases/*'
 
-concurrency: one-job-at-a-time-please
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -22,6 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
+      max-parallel: 1
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,9 @@ on:
     branches:
       - main
       - 'releases/*'
- 
+
+concurrency: one-job-at-a-time-please
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -22,8 +24,6 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-
-    concurrency: ftp_deploy
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,8 @@ on:
       - main
       - 'releases/*'
 
+concurrency:
+ 
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -22,6 +24,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+
+    concurrency: ftp_deploy
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
       - 'releases/*'
-
-concurrency:
  
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ With this Action, you can upload folder contents to an FTP server. **Overwrites 
 
 This Action uploads files straight to the FTP server, without keeping a sync state. If you need a sync state, consider using [SamKirkland/FTP-Deploy-Action](https://github.com/marketplace/actions/ftp-deploy) instead.
 
+Tested and works on:
+- `ubuntu-latest`
+- `windows-latest`
+- `macos-latest`
+
 ## Basic usage
 
 ```YAML


### PR DESCRIPTION
We can only have 1 FTP connection open at the same time on our test server 🤷🏼‍♂️ 